### PR TITLE
Adding "make install" command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ all:
 	gcc $(CFLAGS) -o $(TARGET) jvmkill.c
 	chmod 644 $(TARGET)
 
+install: all
+	install -m 755 $(TARGET) /usr/local/lib
+
 clean:
 	rm -f $(TARGET)
 	rm -f *.class


### PR DESCRIPTION
Having install is a bit useful for us to install jvmkill as a part of build process of Docker images.
