### PR TITLE
Support arm64 build with make arm64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.so
 *.class
 *.hprof
+build
+*~

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+ifndef CC
+CC:=gcc
+endif
+
 ifndef JAVA_HOME
     $(error JAVA_HOME not set)
 endif
@@ -10,17 +14,20 @@ endif
 CFLAGS=-Wall -Werror -fPIC -shared $(INCLUDE)
 
 TARGET=libjvmkill.so
+BUILD_DIR=build
 
 .PHONY: all clean test
 
 all:
-	gcc $(CFLAGS) -o $(TARGET) jvmkill.c
+	@echo "Building jvmkill with $(CC)"
+	$(CC) $(CFLAGS) -o $(TARGET) jvmkill.c
 	chmod 644 $(TARGET)
 
 clean:
 	rm -f $(TARGET)
 	rm -f *.class
 	rm -f *.hprof
+	rm -rf $(BUILD_DIR)
 
 test: all
 	$(JAVA_HOME)/bin/javac JvmKillTest.java
@@ -29,3 +36,12 @@ test: all
 	    -XX:OnOutOfMemoryError='/bin/echo hello' \
 	    -agentpath:$(PWD)/$(TARGET) \
 	    -cp $(PWD) JvmKillTest
+
+# Extract JNI headers from Corretto JDK11 docker image
+jni_headers_arm64:
+	mkdir -p $(BUILD_DIR)/arm64
+	docker run -v `pwd`/$(BUILD_DIR):/work -it amazoncorretto:11 bash -c 'cp -r $${JAVA_HOME}/include /work/arm64/'
+
+# Run cross-compiler for aarch64 (arm64) target
+arm64: jni_headers_arm64
+	./docker/dockcross-aarch64 -a --rm bash -c 'make TARGET=libjvmkill-arm64.so JAVA_HOME=$(BUILD_DIR)/arm64'

--- a/docker/dockcross-aarch64
+++ b/docker/dockcross-aarch64
@@ -1,0 +1,200 @@
+#!/bin/bash
+
+DEFAULT_DOCKCROSS_IMAGE=dockcross/linux-arm64
+
+#------------------------------------------------------------------------------
+# Helpers
+#
+err() {
+    echo -e >&2 ERROR: $@\\n
+}
+
+die() {
+    err $@
+    exit 1
+}
+
+has() {
+    # eg. has command update
+    local kind=$1
+    local name=$2
+
+    type -t $kind:$name | grep -q function
+}
+
+#------------------------------------------------------------------------------
+# Command handlers
+#
+command:update-image() {
+    docker pull $FINAL_IMAGE
+}
+
+help:update-image() {
+    echo Pull the latest $FINAL_IMAGE .
+}
+
+command:update-script() {
+    if cmp -s <( docker run $FINAL_IMAGE ) $0; then
+        echo $0 is up to date
+    else
+        echo -n Updating $0 '... '
+        docker run $FINAL_IMAGE > $0 && echo ok
+    fi
+}
+
+help:update-image() {
+    echo Update $0 from $FINAL_IMAGE .
+}
+
+command:update() {
+    command:update-image
+    command:update-script
+}
+
+help:update() {
+    echo Pull the latest $FINAL_IMAGE, and then update $0 from that.
+}
+
+command:help() {
+    if [[ $# != 0 ]]; then
+        if ! has command $1; then
+            err \"$1\" is not an dockcross command
+            command:help
+        elif ! has help $1; then
+            err No help found for \"$1\"
+        else
+            help:$1
+        fi
+    else
+        cat >&2 <<ENDHELP
+Usage: dockcross [options] [--] command [args]
+
+By default, run the given *command* in an dockcross Docker container.
+
+The *options* can be one of:
+
+    --args|-a           Extra args to the *docker run* command
+    --image|-i          Docker cross-compiler image to use
+    --config|-c         Bash script to source before running this script
+
+
+Additionally, there are special update commands:
+
+    update-image
+    update-script
+    update
+
+For update command help use: $0 help <command>
+ENDHELP
+        exit 1
+    fi
+}
+
+#------------------------------------------------------------------------------
+# Option processing
+#
+special_update_command=''
+while [[ $# != 0 ]]; do
+    case $1 in
+
+        --)
+            break
+            ;;
+
+        --args|-a)
+            ARG_ARGS="$2"
+            shift 2
+            ;;
+
+        --config|-c)
+            ARG_CONFIG="$2"
+            shift 2
+            ;;
+
+        --image|-i)
+            ARG_IMAGE="$2"
+            shift 2
+            ;;
+        update|update-image|update-script)
+            special_update_command=$1
+            break
+            ;;
+        -*)
+            err Unknown option \"$1\"
+            command:help
+            exit
+            ;;
+
+        *)
+            break
+            ;;
+
+    esac
+done
+
+# The precedence for options is:
+# 1. command-line arguments
+# 2. environment variables
+# 3. defaults
+
+# Source the config file if it exists
+DEFAULT_DOCKCROSS_CONFIG=~/.dockcross
+FINAL_CONFIG=${ARG_CONFIG-${DOCKCROSS_CONFIG-$DEFAULT_DOCKCROSS_CONFIG}}
+
+[[ -f "$FINAL_CONFIG" ]] && source "$FINAL_CONFIG"
+
+# Set the docker image
+FINAL_IMAGE=${ARG_IMAGE-${DOCKCROSS_IMAGE-$DEFAULT_DOCKCROSS_IMAGE}}
+
+# Handle special update command
+if [ "$special_update_command" != "" ]; then
+    case $special_update_command in
+
+        update)
+            command:update
+            exit $?
+            ;;
+
+        update-image)
+            command:update-image
+            exit $?
+            ;;
+
+        update-script)
+            command:update-script
+            exit $?
+            ;;
+
+    esac
+fi
+
+# Set the docker run extra args (if any)
+FINAL_ARGS=${ARG_ARGS-${DOCKCROSS_ARGS}}
+
+# If we are not running via boot2docker
+if [ -z $DOCKER_HOST ]; then
+    USER_IDS="-e BUILDER_UID=$( id -u ) -e BUILDER_GID=$( id -g ) -e BUILDER_USER=$( id -un ) -e BUILDER_GROUP=$( id -gn )"
+fi
+
+#------------------------------------------------------------------------------
+# Now, finally, run the command in a container
+#
+docker run --rm \
+    -v $PWD:/work \
+    $USER_IDS \
+    $FINAL_ARGS \
+    $FINAL_IMAGE "$@"
+
+################################################################################
+#
+# This image is not intended to be run manually.
+#
+# To create a dockcross helper script for the
+# dockcross/linux-armv7 image, run:
+#
+# docker run --rm dockcross/linux-armv7 > dockcross-linux-armv7
+# chmod +x dockcross-linux-armv7
+#
+# You may then wish to move the dockcross script to your PATH.
+#
+################################################################################


### PR DESCRIPTION
Added experimental support for building jvmkill for arm64 (jvmkill-arm64.so). This doesn't require using Arm machines as it uses a GCC cross compiler in a docker image of https://github.com/dockcross/dockcross

