### PR TITLE
Fix jvmkill racing with HeapDumpOnOutOfMemoryError leading to truncated heap dumps

### DIFF
--- a/jvmkill.c
+++ b/jvmkill.c
@@ -20,6 +20,132 @@
 
 #include <jvmti.h>
 
+/*
+ * True if -XX:+ExitOnOutOfMemoryError or -XX:+CrashOnOutOfMemoryError was
+ * set at VM init.
+ *
+ * Probed once at VM init via com.sun.management.HotSpotDiagnosticMXBean#
+ * getVMOption(String). Both flags can be flipped at runtime via jcmd VM.set_flag -
+ * we ignore that and trust the value at init time.
+ */
+static volatile int g_jvmWillExitOnOOM = 0;
+
+static int
+readBoolFlag(JNIEnv *env, jobject mxbean,
+             jmethodID getVMOption, jmethodID getValue,
+             const char *flagName)
+{
+   jstring nameStr = (*env)->NewStringUTF(env, flagName);
+   if (nameStr == NULL) { (*env)->ExceptionClear(env); return 0; }
+
+   jobject vmOption = (*env)->CallObjectMethod(env, mxbean, getVMOption, nameStr);
+
+   (*env)->DeleteLocalRef(env, nameStr);
+   if ((*env)->ExceptionCheck(env)) {
+      (*env)->ExceptionClear(env); return 0;
+   }
+   if (vmOption == NULL) return 0;
+
+   jstring valStr = (jstring) (*env)->CallObjectMethod(env, vmOption, getValue);
+   (*env)->DeleteLocalRef(env, vmOption);
+   if ((*env)->ExceptionCheck(env)) {
+      (*env)->ExceptionClear(env); return 0;
+   }
+   if (valStr == NULL) return 0;
+
+   const char *cstr = (*env)->GetStringUTFChars(env, valStr, NULL);
+   int isTrue = (cstr != NULL && strcmp(cstr, "true") == 0);
+   if (cstr != NULL) (*env)->ReleaseStringUTFChars(env, valStr, cstr);
+   (*env)->DeleteLocalRef(env, valStr);
+   return isTrue;
+}
+
+static void JNICALL
+vmInit(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread)
+{
+   /*
+    * Walk:
+    *   ManagementFactory.getPlatformMXBean(HotSpotDiagnosticMXBean.class)
+    *     .getVMOption("ExitOnOutOfMemoryError").getValue()
+    *     .equals("true")
+    *
+    * Any failure (class not found, exception thrown, null result) leaves
+    * g_jdkWillExitOnOOM == 0, which is the safe default: the agent will
+    * SIGKILL on every OOM, matching the pre-introspection behavior.
+    */
+   jclass diagCls = (*env)->FindClass(env,
+      "com/sun/management/HotSpotDiagnosticMXBean");
+   if (diagCls == NULL) {
+      (*env)->ExceptionClear(env);
+      fprintf(stderr,
+         "jvmkill: HotSpotDiagnosticMXBean not found "
+         "(jdk.management module missing?) -- "
+         "falling back to kill-on-every-OOM\n");
+      return;
+   }
+
+   jclass mfCls = (*env)->FindClass(env,
+      "java/lang/management/ManagementFactory");
+   if (mfCls == NULL) {
+      (*env)->ExceptionClear(env);
+      fprintf(stderr,
+         "jvmkill: ManagementFactory not found -- "
+         "falling back to kill-on-every-OOM\n");
+      return;
+   }
+
+   jmethodID getPlatformMXBean = (*env)->GetStaticMethodID(env, mfCls,
+      "getPlatformMXBean",
+      "(Ljava/lang/Class;)Ljava/lang/management/PlatformManagedObject;");
+   if (getPlatformMXBean == NULL) {
+      (*env)->ExceptionClear(env); return;
+   }
+
+   jobject mxbean = (*env)->CallStaticObjectMethod(env, mfCls,
+      getPlatformMXBean, diagCls);
+   if ((*env)->ExceptionCheck(env)) {
+      (*env)->ExceptionClear(env); return;
+   }
+   if (mxbean == NULL) {
+      fprintf(stderr,
+         "jvmkill: getPlatformMXBean(HotSpotDiagnosticMXBean) returned null "
+         "-- falling back to kill-on-every-OOM\n");
+      return;
+   }
+
+   jmethodID getVMOption = (*env)->GetMethodID(env, diagCls,
+      "getVMOption",
+      "(Ljava/lang/String;)Lcom/sun/management/VMOption;");
+   if (getVMOption == NULL) {
+      (*env)->ExceptionClear(env); return;
+   }
+
+   jclass vmOptCls = (*env)->FindClass(env, "com/sun/management/VMOption");
+   if (vmOptCls == NULL) {
+      (*env)->ExceptionClear(env); return;
+   }
+   jmethodID getValue = (*env)->GetMethodID(env, vmOptCls,
+      "getValue", "()Ljava/lang/String;");
+   if (getValue == NULL) {
+      (*env)->ExceptionClear(env); return;
+   }
+
+   int exitSet  = readBoolFlag(env, mxbean, getVMOption, getValue,
+                               "ExitOnOutOfMemoryError");
+   int crashSet = readBoolFlag(env, mxbean, getVMOption, getValue,
+                               "CrashOnOutOfMemoryError");
+
+   g_jvmWillExitOnOOM = (exitSet || crashSet);
+
+   fprintf(stderr,
+      "jvmkill: ExitOnOutOfMemoryError=%s CrashOnOutOfMemoryError=%s -- "
+      "mode=%s\n",
+      exitSet  ? "true" : "false",
+      crashSet ? "true" : "false",
+      g_jvmWillExitOnOOM ? "JVM handles OOM"
+                         : "kill-on-every-OOM");
+}
+
 static void JNICALL
 resourceExhausted(
       jvmtiEnv *jvmti_env,
@@ -28,10 +154,35 @@ resourceExhausted(
       const void *reserved,
       const char *description)
 {
-   fprintf(stderr,
-      "ResourceExhausted: %s: killing current process!\n", description);
-   kill(getpid(), SIGKILL);
-   _exit(1);
+   if (g_jvmWillExitOnOOM
+       && flags == (JVMTI_RESOURCE_EXHAUSTED_OOM_ERROR
+                  | JVMTI_RESOURCE_EXHAUSTED_JAVA_HEAP)) {
+      fprintf(
+         stderr,
+         "jvmkill: JVMTI ResourceExhausted OOM_ERROR|JAVA_HEAP "
+         "\"%s\" [flags=0x%x]\n",
+         description,
+         flags);
+   }
+   else if (g_jvmWillExitOnOOM
+            && flags == JVMTI_RESOURCE_EXHAUSTED_OOM_ERROR) {
+      fprintf(
+         stderr,
+         "jvmkill: JVMTI ResourceExhausted OOM_ERROR "
+         "\"%s\" [flags=0x%x]\n",
+         description,
+         flags);
+   }
+   else {
+      fprintf(
+         stderr,
+         "jvmkill: JVMTI ResourceExhausted  OOM_ERROR | THREADS"
+         "\"%s\" [flags=0x%x] -- killing process (SIGKILL)\n",
+         description,
+         flags);
+      kill(getpid(), SIGKILL);
+      _exit(1);
+   }
 }
 
 JNIEXPORT jint JNICALL
@@ -50,6 +201,7 @@ Agent_OnLoad(JavaVM *vm, char *options, void *reserved)
    memset(&callbacks, 0, sizeof(callbacks));
 
    callbacks.ResourceExhausted = &resourceExhausted;
+   callbacks.VMInit            = &vmInit;
 
    err = (*jvmti)->SetEventCallbacks(jvmti, &callbacks, sizeof(callbacks));
    if (err != JVMTI_ERROR_NONE) {
@@ -60,7 +212,14 @@ Agent_OnLoad(JavaVM *vm, char *options, void *reserved)
    err = (*jvmti)->SetEventNotificationMode(
          jvmti, JVMTI_ENABLE, JVMTI_EVENT_RESOURCE_EXHAUSTED, NULL);
    if (err != JVMTI_ERROR_NONE) {
-      fprintf(stderr, "ERROR: SetEventNotificationMode failed: %d\n", err);
+      fprintf(stderr, "ERROR: SetEventNotificationMode(ResourceExhausted) failed: %d\n", err);
+      return JNI_ERR;
+   }
+
+   err = (*jvmti)->SetEventNotificationMode(
+         jvmti, JVMTI_ENABLE, JVMTI_EVENT_VM_INIT, NULL);
+   if (err != JVMTI_ERROR_NONE) {
+      fprintf(stderr, "ERROR: SetEventNotificationMode(VMInit) failed: %d\n", err);
       return JNI_ERR;
    }
 


### PR DESCRIPTION
 ## Overview
`jvmkill` calls `kill(getpid(), SIGKILL)` from every JVMTI [`ResourceExhausted`](https://docs.oracle.com/en/java/javase/21/docs/specs/jvmti.html#ResourceExhausted) event. On JDK 22+, this races with the JDK's own `-XX:+HeapDumpOnOutOfMemoryError` handler and truncates the resulting `.hprof`.

On JDK ≤ 21, the entire heap dump ran inside a single `VM_HeapDumper` VM operation at safepoint. While that safepoint was held, all Java threads - including threads that lost the [`report_java_out_of_memory`](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/utilities/debug.cpp) CAS latch and were carrying the JVMTI callback were frozen. The agent's `SIGKILL` could only fire after the dump finished and the safepoint was released, so the `.hprof` was always complete on disk.
[JDK-8306441](https://bugs.openjdk.org/browse/JDK-8306441) (JDK 22) split the dump so that the segment-merge phase runs **outside the safepoint**. Loser-of-CAS hreads now unfreeze while the merge is still writing to disk, reach the JVMTI callback, and `jvmkill` kills the process mid-write truncating the `.hprof`.

 ## Changes

Add a `VMInit` callback that probes `HotSpotDiagnosticMXBean` at startup to detect whether `ExitOnOutOfMemoryError` or `CrashOnOutOfMemoryError` is set. When neither `ExitOnOutOfMemoryError` nor `CrashOnOutOfMemoryError` is set, the agent continues to SIGKILL for backward compatibility.  Route `ResourceExhausted` events based on the [`flags argument`](https://github.com/openjdk/jdk/blob/3c69c9699411567bbc1f42c9369454c206b6a9c3/src/hotspot/share/prims/jvmti.xml#L13901) :
  | OOM source           | Flags                     | Old behavior | New behavior |
  |----------------------|---------------------------|--------------|--------------|
  | Java heap ([memAllocator.cpp](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/gc/shared/memAllocator.cpp)) | `OOM_ERROR\|JAVA_HEAP` (`0x3`) | SIGKILL | log only — JDK handles shutdown |
  | Metaspace([metaspace.cpp](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/memory/metaspace.cpp)) |`OOM_ERROR` (`0x1`) | SIGKILL | log only — JDK handles shutdown | 
| Native thread create ([jvm.cpp](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/prims/jvm.cpp)) | `OOM_ERROR\|THREADS` (`0x5`) | SIGKILL | SIGKILL |

For Java heap and metaspace OOM, [`report_java_out_of_memory`](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/utilities/debug.cpp) runs upstream of the JVMTI callback - the JDK has already started its dump and will terminate the process. Killing unconditionally races with the dump write ([heapDumper.cpp](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/services/heapDumper.cpp)) and truncates the `.hprof`. 

Native thread OOM has no JDK-side handler; SIGKILL there is unchanged.

Fixes https://github.com/trinodb/trino/issues/29301