### PR TITLE
Only kill the JVM when thread creation fails

### DIFF
--- a/JvmKillTest.java
+++ b/JvmKillTest.java
@@ -11,27 +11,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import java.util.ArrayList;
-import java.util.List;
-
 public final class JvmKillTest
 {
     @SuppressWarnings("InfiniteLoopStatement")
     public static void main(String[] args)
-            throws Exception
     {
-        System.out.println("triggering OutOfMemory...");
-        List<Object> list = new ArrayList<>();
-        try {
-            while (true) {
-                byte[] bytes = new byte[1024 * 1024 * 1024];
-                list.add(bytes);
-                System.out.println("list size: " + list.size());
-            }
+        System.out.println("triggering thread exhaustion...");
+        int count = 0;
+        while (true) {
+            Thread thread = new Thread(() -> {});
+            thread.start();
+            count++;
+            System.out.println("threads: " + count);
         }
-        catch (Throwable t) {
-            System.out.println(t.toString());
-        }
-        System.out.println("final list size: " + list.size());
     }
 }

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,6 @@ clean:
 
 test: all
 	$(JAVA_HOME)/bin/javac JvmKillTest.java
-	$(JAVA_HOME)/bin/java -Xmx8m \
-	    -XX:+HeapDumpOnOutOfMemoryError \
-	    -XX:OnOutOfMemoryError='/bin/echo hello' \
+	$(JAVA_HOME)/bin/java -Xss512m \
 	    -agentpath:$(PWD)/$(TARGET) \
 	    -cp $(PWD) JvmKillTest

--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
 # Overview
 
 **jvmkill** is a simple [JVMTI][] agent that forcibly terminates the JVM
-when it is unable to allocate memory or create a thread. This is important
-for reliability purposes: an `OutOfMemoryError` or thread creation failure
-will often leave the JVM in an inconsistent state. Terminating the JVM will
-allow it to be restarted by an external process manager.
+when it is unable to create a thread. This is important for reliability
+purposes: a thread creation failure will often leave the JVM in an
+inconsistent state. Terminating the JVM will allow it to be restarted by
+an external process manager.
 
 [JVMTI]: http://docs.oracle.com/javase/8/docs/technotes/guides/jvmti/
 
-It is often useful to automatically dump the Java heap using the
-`-XX:+HeapDumpOnOutOfMemoryError` JVM argument. This agent will be
-notified and terminate the JVM after the heap dump completes.
+For out-of-memory conditions (heap or metaspace exhaustion), use
+`-XX:+ExitOnOutOfMemoryError`.
 
 # Building
 
@@ -24,17 +23,3 @@ Run Java with the agent added as a JVM argument:
 
 Alternatively, if modifying the Java command line is not possible, the
 above may be added to the `JAVA_TOOL_OPTIONS` environment variable.
-
-# Alternatives
-
-Newer JVMs (8u92+) support the `-XX:ExitOnOutOfMemoryError` option to
-exit on out of memory. Unfortunately, this option does not cover thread
-creation failure, therefore we still recommend using this agent. It is
-fine to use the agent in combination with this JVM option.
-
-For older JVMs, a common alternative to this agent is to use the
-`-XX:OnOutOfMemoryError` JVM argument to execute a `kill -9` command.
-Unfortunately, the JVM uses the `fork()` system call to execute the kill
-command and that system call can fail for large JVMs due to memory
-overcommit limits in the operating system. Additionally, as with
-`-XX:ExitOnOutOfMemoryError`, this does not cover thread creation failure.

--- a/jvmkill.c
+++ b/jvmkill.c
@@ -28,10 +28,12 @@ resourceExhausted(
       const void *reserved,
       const char *description)
 {
-   fprintf(stderr,
-      "ResourceExhausted: %s: killing current process!\n", description);
-   kill(getpid(), SIGKILL);
-   _exit(1);
+   if (flags & JVMTI_RESOURCE_EXHAUSTED_THREADS) {
+      fprintf(stderr,
+         "ResourceExhausted: %s: killing current process!\n", description);
+      kill(getpid(), SIGKILL);
+      _exit(1);
+   }
 }
 
 JNIEXPORT jint JNICALL


### PR DESCRIPTION
## Description
Killing the JVM due to OOM will interrupt the heap dumper.

Fixes https://github.com/trinodb/trino/issues/29301